### PR TITLE
fix goroutine leak

### DIFF
--- a/honey_badger.go
+++ b/honey_badger.go
@@ -209,7 +209,17 @@ func (hb *HoneyBadger) getOrNewACSInstance(epoch uint64) *ACS {
 
 // removeOldEpochs removes the ACS instances that have already been terminated.
 func (hb *HoneyBadger) removeOldEpochs(epoch uint64) {
-	for i := epoch; i < hb.epoch-1; i++ {
+	for i, acs := range hb.acsInstances {
+		if i >= hb.epoch-1 {
+			continue
+		}
+		for _, t := range acs.bbaInstances {
+			t.stop()
+		}
+		for _, t := range acs.rbcInstances {
+			t.stop()
+		}
+		acs.stop()
 		delete(hb.acsInstances, i)
 	}
 }

--- a/simulation/main.go
+++ b/simulation/main.go
@@ -26,7 +26,7 @@ type message struct {
 var (
 	txDelay  = (3 * time.Millisecond) / numCores
 	messages = make(chan message, 1024*1024)
-	relayCh  = make(chan *Transaction, 1024)
+	relayCh  = make(chan *Transaction, 1024*1024)
 )
 
 func main() {
@@ -47,8 +47,7 @@ func main() {
 
 	// handle the relayed transactions.
 	go func() {
-		for {
-			tx := <-relayCh
+		for tx := range relayCh {
 			for _, node := range nodes {
 				node.addTransactions(tx)
 			}


### PR DESCRIPTION
Hello!

I've noticed that when ACS/RBC/BBA-instances of old epochs are deleted, corresponding goroutines for ACS/RBC/BBA are not stopped. This PR fixes it.

I've also increased size of `relayCh` in `simulation/main.go` just to be sure that number of goroutines is really not increasing.

Let me know, what do you think.